### PR TITLE
add ren website (wren.io-style landing page)

### DIFF
--- a/docs/ren/index.html
+++ b/docs/ren/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ren &mdash; tiny reader macros for Common Lisp</title>
+<meta name="description" content="ren is a five-macro extension to Common Lisp for code that fits in your head.">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header>
+  <div class="container">
+    <a href="#" class="logo">ren</a>
+    <nav>
+      <a href="#why">Why</a>
+      <a href="#try">Try It</a>
+      <a href="#macros">Macros</a>
+      <a href="#example">Example</a>
+      <a href="https://github.com/timm/lisp">Source</a>
+    </nav>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="container">
+    <h1>A Common Lisp dialect <br>that fits in your head.</h1>
+    <p class="tagline">
+      <strong>ren</strong> is five reader-macros, thirty lines of code,
+      and one rule: the subject is implicit.
+    </p>
+<pre><code><span class="c">;; methods read like prose &mdash; `i` is self, `$x` is its slot</span>
+(defmethod add ((i num) v)
+  (incf <span class="m">$n</span>)
+  (let ((d (- v <span class="m">$mu</span>)))
+    (incf <span class="m">$mu</span> (/ d <span class="m">$n</span>))
+    (incf <span class="m">$m2</span> (* d (- v <span class="m">$mu</span>)))))
+
+<span class="c">;; chain through structures, look up config, bind `it`</span>
+(when (< (<span class="m">?</span> data cols n) <span class="m">!budget</span>)
+  (<span class="m">aif</span> (next-row pool)
+       (label it)))</code></pre>
+  </div>
+</section>
+
+<section id="why">
+  <div class="container">
+    <h2>Why ren?</h2>
+    <div class="grid">
+      <div class="cell">
+        <h3>Tiny</h3>
+        <p>The whole language is one file: a reader-macro definer plus
+           four reader macros. Drop it in, <code>(load "lib")</code>,
+           and you're done.</p>
+      </div>
+      <div class="cell">
+        <h3>Anaphoric</h3>
+        <p>In a method, <code>i</code> is always self. In an
+           <code>aif</code>, <code>it</code> is always the test.
+           No more boilerplate <code>let</code>-bindings.</p>
+      </div>
+      <div class="cell">
+        <h3>Composable</h3>
+        <p><code>$</code>, <code>!</code>, and <code>?</code> read
+           as Lisp forms. They <code>setf</code>, they
+           <code>incf</code>, they nest &mdash; they're invisible
+           until you look.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="try">
+  <div class="container">
+    <h2>Try it</h2>
+    <p>Two files. No build system, no package manager, no
+       <code>asdf:load-system</code>. If you have CLISP or SBCL,
+       you have ren.</p>
+<pre><code>$ git clone https://github.com/timm/lisp
+$ cd lisp
+$ sbcl --script fri2.lisp --stats
+$ clisp fri2.lisp --tree</code></pre>
+  </div>
+</section>
+
+<section id="macros">
+  <div class="container">
+    <h2>The five macros</h2>
+
+    <article>
+      <h3><code class="m">!key</code></h3>
+      <p class="lead">Config lookup.</p>
+      <p>Reads from <code>*the*</code>, an alist of
+         <code>(name value flag doc)</code> tuples.
+         The flag and doc serve double duty as the
+         command-line spec.</p>
+<pre><code><span class="m">!budget</span>   <span class="c">;; &equiv;</span>   (second (assoc 'budget *the*))</code></pre>
+    </article>
+
+    <article>
+      <h3><code class="m">$field</code></h3>
+      <p class="lead">Self slot access.</p>
+      <p>Inside a method whose first parameter is named
+         <code>i</code>, <code>$field</code> expands to
+         <code>(slot-value i 'field)</code>. Works with
+         <code>setf</code>, <code>incf</code>, and friends.</p>
+<pre><code>(defmethod mid ((i num)) <span class="m">$mu</span>)
+
+(defmethod add ((i sym) v &amp;optional (w 1))
+  (unless (eql v '?)
+    (incf <span class="m">$n</span> w)))</code></pre>
+    </article>
+
+    <article>
+      <h3><code class="m">(? x a b c)</code></h3>
+      <p class="lead">Nested slot access.</p>
+      <p>Chains <code>slot-value</code> calls. <code>setf</code>-able.
+         Replaces the noisy <code>(slot-value (slot-value ...))</code>
+         tower.</p>
+<pre><code>(<span class="m">?</span> data cols y)
+<span class="c">;; &equiv;</span>
+(slot-value (slot-value data 'cols) 'y)</code></pre>
+    </article>
+
+    <article>
+      <h3><code class="m">(aif test then else)</code></h3>
+      <p class="lead">Anaphoric if.</p>
+      <p>Binds the test result to <code>it</code> in both
+         branches. Borrowed from Paul Graham's
+         <em>On Lisp</em>.</p>
+<pre><code>(<span class="m">aif</span> (find flag opts :key #'third :test #'equalp)
+     (setf (second it) (thing arg)))</code></pre>
+    </article>
+
+    <article>
+      <h3><code class="m">(defread c (s) body)</code></h3>
+      <p class="lead">Reader-macro definer.</p>
+      <p>Installs a one-character reader macro. The other four
+         macros are all built with this. Six lines of code,
+         and the language extends itself.</p>
+<pre><code>(<span class="m">defread</span> $(s)
+  `(slot-value i ',(read s t nil t)))
+
+(<span class="m">defread</span> !(s)
+  `(second (assoc ',(read s t nil t) *the*)))</code></pre>
+    </article>
+  </div>
+</section>
+
+<section id="example">
+  <div class="container">
+    <h2>A complete example</h2>
+    <p>Here is a streaming numeric summary &mdash; mean and
+       standard deviation in constant memory, using Welford's
+       method &mdash; written in plain Common Lisp on the left,
+       and in ren on the right.</p>
+
+    <div class="compare">
+      <div>
+        <h4>Plain Common Lisp</h4>
+<pre><code>(defmethod add ((self num) v)
+  (incf (slot-value self 'n))
+  (let ((d (- v (slot-value self 'mu))))
+    (incf (slot-value self 'mu)
+          (/ d (slot-value self 'n)))
+    (incf (slot-value self 'm2)
+          (* d (- v (slot-value self 'mu))))))</code></pre>
+      </div>
+      <div>
+        <h4>ren</h4>
+<pre><code>(defmethod add ((i num) v)
+  (incf <span class="m">$n</span>)
+  (let ((d (- v <span class="m">$mu</span>)))
+    (incf <span class="m">$mu</span> (/ d <span class="m">$n</span>))
+    (incf <span class="m">$m2</span> (* d (- v <span class="m">$mu</span>)))))</code></pre>
+      </div>
+    </div>
+
+    <p>Same code, half the noise, no new concepts. ren doesn't
+       hide Lisp &mdash; it gets out of the way.</p>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>
+      &copy; 2026 Tim Menzies &middot;
+      <a href="https://github.com/timm/lisp/blob/main/LICENSE.md">MIT License</a> &middot;
+      <a href="https://github.com/timm/lisp">Source on GitHub</a>
+    </p>
+    <p class="small">
+      Inspired by <a href="https://wren.io/">wren</a>,
+      <em>On Lisp</em>, and the conviction that small is beautiful.
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/ren/style.css
+++ b/docs/ren/style.css
@@ -1,0 +1,225 @@
+/* ren --- styled after wren.io */
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  background: #fdfaf3;
+  color: #2a2620;
+  font-family: Georgia, "Times New Roman", Times, serif;
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+a { color: #b8451f; text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ----- header ----- */
+
+header {
+  background: #fdfaf3;
+  border-bottom: 1px solid #e8dcc4;
+  padding: 22px 0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+header .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+}
+
+.logo {
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue",
+               Helvetica, Arial, sans-serif;
+  font-size: 30px;
+  font-weight: 800;
+  color: #b8451f;
+  letter-spacing: -1.5px;
+  line-height: 1;
+}
+.logo:hover { text-decoration: none; color: #8a3416; }
+
+nav a {
+  color: #5a4a3a;
+  font-size: 14px;
+  margin-left: 22px;
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue",
+               Helvetica, Arial, sans-serif;
+}
+nav a:first-child { margin-left: 0; }
+nav a:hover { color: #b8451f; text-decoration: none; }
+
+/* ----- sections ----- */
+
+section { padding: 52px 0; }
+section + section { border-top: 1px solid #efe6d2; }
+
+#why { background: #fbf4e4; }
+#try { background: #fdfaf3; }
+
+h1, h2, h3, h4 {
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue",
+               Helvetica, Arial, sans-serif;
+  color: #1a1612;
+  line-height: 1.25;
+}
+
+h1 {
+  font-size: 38px;
+  font-weight: 800;
+  letter-spacing: -1px;
+  margin-bottom: 18px;
+}
+
+h2 {
+  font-size: 26px;
+  font-weight: 700;
+  margin-bottom: 22px;
+  padding-bottom: 6px;
+  border-bottom: 2px solid #b8451f;
+  display: inline-block;
+}
+
+h3 {
+  font-size: 19px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: #1a1612;
+}
+
+h4 {
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #8a6a4a;
+  margin-bottom: 8px;
+}
+
+p { margin-bottom: 14px; }
+
+p.lead {
+  color: #6a5a4a;
+  font-style: italic;
+  margin-bottom: 10px;
+}
+
+strong { color: #1a1612; }
+
+/* ----- hero ----- */
+
+.hero { padding: 70px 0 60px; }
+
+.hero h1 { margin-bottom: 22px; }
+
+.hero .tagline {
+  font-size: 19px;
+  color: #4a3e30;
+  margin-bottom: 32px;
+  max-width: 640px;
+}
+
+/* ----- code ----- */
+
+pre {
+  background: #f5ead4;
+  border: 1px solid #e8dcc4;
+  border-radius: 4px;
+  padding: 16px 20px;
+  margin: 18px 0;
+  overflow-x: auto;
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+
+code {
+  font-family: "SF Mono", Menlo, Consolas, "Liberation Mono",
+               "Courier New", monospace;
+  color: #3a2a1a;
+}
+
+p code, li code, h3 code {
+  background: #f5ead4;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.88em;
+  color: #5a3a1a;
+}
+
+h3 code.m,
+pre code .m {
+  color: #b8451f;
+  font-weight: 600;
+  background: transparent;
+  padding: 0;
+}
+
+pre code .c {
+  color: #997a55;
+  font-style: italic;
+}
+
+/* ----- features grid ----- */
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 28px;
+  margin-top: 8px;
+}
+
+@media (min-width: 720px) {
+  .grid { grid-template-columns: repeat(3, 1fr); gap: 32px; }
+}
+
+.cell h3 { color: #b8451f; }
+.cell p { font-size: 16px; }
+
+/* ----- macro articles ----- */
+
+article {
+  margin: 32px 0 40px;
+  padding-bottom: 28px;
+  border-bottom: 1px dashed #e0d4bc;
+}
+article:last-child { border-bottom: none; padding-bottom: 0; }
+article h3 { margin-bottom: 6px; }
+
+/* ----- compare ----- */
+
+.compare {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+  margin: 22px 0;
+}
+
+@media (min-width: 720px) {
+  .compare { grid-template-columns: 1fr 1fr; gap: 18px; }
+}
+
+.compare pre { margin: 6px 0 0; }
+
+/* ----- footer ----- */
+
+footer {
+  border-top: 1px solid #e8dcc4;
+  padding: 28px 0;
+  text-align: center;
+  color: #6a5a4a;
+  font-size: 14px;
+}
+footer p { margin-bottom: 6px; }
+footer .small { font-size: 13px; color: #8a7a6a; font-style: italic; }


### PR DESCRIPTION
Static site at docs/ren/ describing the five reader macros in
lib.lisp ($, !, ?, aif, defread) as a tiny CL dialect called "ren".
Single-page index.html with separate stylesheet, no JS, no build
step.

https://claude.ai/code/session_015v2sagBXvLm1T5HBnVyJ47